### PR TITLE
Modularize democracy tracker UI and add data-driven insights

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const eslintConfig = [
       ".next/**",
       "out/**",
       "build/**",
+      "docs/**",
       "next-env.d.ts",
     ],
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,374 +1,76 @@
 'use client';
 
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { motion } from 'framer-motion'
-import { Slider } from '@/components/ui/slider'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
-import { ArrowUpRight, ArrowDownRight, Download, RefreshCw } from 'lucide-react'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import html2canvas from 'html2canvas'
-
-/**
- * DEMOCRACY TRACKER — CARD + SCROLLABLE DEEP-DIVE
- * -------------------------------------------------
- * • Top: Shareable "infographic card" for social posts (no scroll needed)
- * • Below: Scrollable deep-dive with ledger, categories, weights, history
- * • Export button: saves the top card as a PNG for easy posting
- */
-
-const CATEGORIES = [
-  'Legislative',
-  'Executive',
-  'Judicial',
-  'Elections',
-  'Rights & Liberties',
-  'Civil Society',
-  'Political Violence',
-] as const
-
-type Category = typeof CATEGORIES[number]
-
-export type EventItem = {
-  id: string
-  date: string // ISO
-  title: string
-  summary?: string
-  url?: string
-  category: Category
-  direction: 1 | -1 // +1 = towards democracy, -1 = towards autocracy
-  magnitude: number // 0.5..5 typical; can exceed
-  confidence: number // 0..1
-}
-
-const clamp = (x: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, x))
-
-function computeCategoryScores(events: EventItem[], now = new Date()): Record<Category, number> {
-  const halfLifeDays = 365
-  const lambda = Math.log(2) / halfLifeDays
-  const base: Record<Category, number> = Object.fromEntries(CATEGORIES.map(c => [c, 0])) as any
-  for (const e of events) {
-    const ageDays = Math.max(0, (now.getTime() - new Date(e.date).getTime()) / (1000*60*60*24))
-    const decay = Math.exp(-lambda * ageDays)
-    const signedImpact = e.direction * e.magnitude * e.confidence * decay
-    base[e.category] += signedImpact
-  }
-  const norm: Record<Category, number> = { ...base } as any
-  for (const k of CATEGORIES) norm[k] = Math.tanh(base[k] / 10) * 100
-  return norm
-}
-
-function weightedIndex(categoryScores: Record<Category, number>, weights: Record<Category, number>) {
-  const totalW = Object.values(weights).reduce((a, b) => a + b, 0) || 1
-  const sum = (CATEGORIES as readonly Category[]).reduce((acc, c) => acc + categoryScores[c] * weights[c], 0)
-  return sum / totalW
-}
-
-// --- Demo seed ---
-const seedEvents: EventItem[] = [
-  {
-    id: 'seed-1',
-    date: new Date(Date.now() - 3 * 24 * 3600 * 1000).toISOString(),
-    title: 'Court curtails gerrymandered map',
-    category: 'Elections',
-    direction: 1,
-    magnitude: 2.5,
-    confidence: 0.9,
-    url: '#',
-  },
-  {
-    id: 'seed-2',
-    date: new Date(Date.now() - 1 * 24 * 3600 * 1000).toISOString(),
-    title: 'Legislature advances voter ID expansion',
-    category: 'Elections',
-    direction: -1,
-    magnitude: 2.0,
-    confidence: 0.8,
-  },
-  {
-    id: 'seed-3',
-    date: new Date().toISOString(),
-    title: 'Peaceful mass protest for press freedom',
-    category: 'Civil Society',
-    direction: 1,
-    magnitude: 1.2,
-    confidence: 0.7,
-  },
-]
+import { Download } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ShareCard } from '@/components/tracker/share-card'
+import { DeepDive } from '@/components/tracker/deep-dive'
+import { WeightsPanel } from '@/components/tracker/weights-panel'
+import {
+  CategoryScores,
+  CategoryWeights,
+  EventItem,
+  ScoreHistoryPoint,
+  computeCategoryScores,
+  createDefaultWeights,
+  seedEvents,
+  weightedIndex,
+} from '@/lib/democracy'
 
 export default function DemocracyTracker() {
   const [events, setEvents] = useState<EventItem[]>(seedEvents)
-  const [weights, setWeights] = useState<Record<Category, number>>(() =>
-    Object.fromEntries(CATEGORIES.map(c => [c, 1])) as Record<Category, number>
-  )
-  const [history, setHistory] = useState<{ ts: number; value: number }[]>([])
+  const [weights, setWeights] = useState<CategoryWeights>(() => createDefaultWeights())
+  const [history, setHistory] = useState<ScoreHistoryPoint[]>([])
 
-  const categoryScores = useMemo(() => computeCategoryScores(events), [events])
+  const categoryScores = useMemo<CategoryScores>(() => computeCategoryScores(events), [events])
   const index = useMemo(() => weightedIndex(categoryScores, weights), [categoryScores, weights])
 
-  // Sparkline history (client-only)
   useEffect(() => {
-    const t = setInterval(() => setHistory(h => [...h.slice(-199), { ts: Date.now(), value: index }]), 2000)
-    return () => clearInterval(t)
+    setHistory(previous => [...previous.slice(-199), { ts: Date.now(), value: index }])
   }, [index])
 
-  // Export card as PNG
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setHistory(previous => [...previous.slice(-199), { ts: Date.now(), value: index }])
+    }, 2000)
+    return () => clearInterval(timer)
+  }, [index])
+
   const cardRef = useRef<HTMLDivElement | null>(null)
+
   async function handleExport() {
     if (!cardRef.current) return
     const canvas = await html2canvas(cardRef.current, { backgroundColor: '#ffffff', scale: 2 })
     const link = document.createElement('a')
-    link.download = `democracy-tracker-${new Date().toISOString().slice(0,10)}.png`
+    link.download = `democracy-tracker-${new Date().toISOString().slice(0, 10)}.png`
     link.href = canvas.toDataURL('image/png')
     link.click()
   }
 
   return (
     <div className="min-h-screen bg-white">
-      {/* TOP CARD (shareable, no scroll needed) */}
-      <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
-        <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+      <div className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3">
           <div className="text-lg font-semibold">U.S. Democracy Tracker</div>
           <div className="flex items-center gap-2 text-xs opacity-70">{new Date().toLocaleString()}</div>
-          <Button onClick={handleExport} size="sm" className="shrink-0"><Download className="w-4 h-4 mr-2"/>Export Card</Button>
+          <Button onClick={handleExport} size="sm" className="shrink-0">
+            <Download className="mr-2 h-4 w-4" />
+            Export Card
+          </Button>
         </div>
       </div>
 
-      <section className="max-w-5xl mx-auto px-4 py-6">
-        <div ref={cardRef} className="rounded-3xl border shadow-sm p-5 md:p-6 bg-white">
+      <section className="mx-auto max-w-5xl px-4 py-6">
+        <div ref={cardRef} className="rounded-3xl border bg-white p-5 shadow-sm md:p-6">
           <ShareCard index={index} history={history} categoryScores={categoryScores} events={events} />
         </div>
       </section>
 
-      {/* SCROLLABLE DEEP-DIVE */}
-      <main className="max-w-5xl mx-auto px-4 pb-16 space-y-8">
+      <main className="mx-auto max-w-5xl space-y-8 px-4 pb-16">
         <DeepDive events={events} setEvents={setEvents} categoryScores={categoryScores} />
         <WeightsPanel weights={weights} setWeights={setWeights} />
       </main>
     </div>
   )
 }
-
-function ShareCard({ index, history, categoryScores, events }: { index: number; history: {ts:number; value:number}[]; categoryScores: Record<Category, number>; events: EventItem[] }) {
-  return (
-    <div className="grid md:grid-cols-5 gap-6">
-      {/* Left: Main bar + number */}
-      <div className="md:col-span-3 space-y-3">
-        <h1 className="text-2xl md:text-3xl font-bold">Today’s Index: {index.toFixed(1)}</h1>
-        <div className="relative h-16 rounded-2xl bg-gray-100 overflow-hidden">
-          <div className="absolute inset-0 flex"><div className="w-1/2 h-full bg-red-50"/><div className="w-1/2 h-full bg-green-50"/></div>
-          <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
-          <motion.div className="absolute top-0 h-full w-1.5 bg-black rounded" initial={{ x: '50%' }} animate={{ x: `${50 + (index/2)}%` }} transition={{ type: 'spring', stiffness: 120, damping: 20 }} />
-          <div className="absolute inset-0 flex items-center justify-between px-3 text-xs font-medium"><span>-100 Autocracy</span><span>0</span><span>+100 Democracy</span></div>
-        </div>
-        <div className="h-24">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={history.map(h => ({ t: new Date(h.ts).toLocaleTimeString(), v: h.value }))}>
-              <XAxis dataKey="t" hide /><YAxis domain={[-100, 100]} hide />
-              <Tooltip formatter={(v: any) => (typeof v === 'number' ? v.toFixed(1) : v)} />
-              <Line type="monotone" dataKey="v" dot={false} />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-
-      {/* Right: Category snapshot + top moves */}
-      <div className="md:col-span-2 space-y-4">
-        <Card>
-          <CardHeader className="py-3"><CardTitle className="text-sm">Category Snapshot</CardTitle></CardHeader>
-          <CardContent className="grid grid-cols-2 gap-3">
-            {CATEGORIES.map(c => (
-              <div key={c} className="text-sm">
-                <div className="flex items-center justify-between">
-                  <span className="opacity-70">{c}</span>
-                  <span className="font-medium">{categoryScores[c].toFixed(0)}</span>
-                </div>
-                <div className="relative h-2 rounded-full bg-gray-100 overflow-hidden">
-                  <div className="absolute inset-0 flex"><div className="w-1/2 h-full bg-red-50"/><div className="w-1/2 h-full bg-green-50"/></div>
-                  <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
-                  <motion.div className="absolute top-0 h-full bg-black" initial={{ x: '50%', width: '3%' }} animate={{ x: `${50 + (categoryScores[c]/2)}%` }} transition={{ type: 'spring', stiffness: 120, damping: 20 }} style={{ width: '3%' }} />
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="py-3"><CardTitle className="text-sm">Today’s Moves</CardTitle></CardHeader>
-          <CardContent className="space-y-2">
-            {events.slice(0,3).map(e => <EventRow key={e.id} e={e} />)}
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  )
-}
-
-function DeepDive({ events, setEvents, categoryScores }: { events: EventItem[]; setEvents: React.Dispatch<React.SetStateAction<EventItem[]>>; categoryScores: Record<Category, number> }) {
-  // Quick add form
-  const [qa, setQa] = useState<Partial<EventItem>>({ title: '', category: 'Legislative', direction: 1, magnitude: 1.0, confidence: 0.8 })
-  const [importText, setImportText] = useState('')
-
-  function addEvent(e: Partial<EventItem>) {
-    const item: EventItem = {
-      id: `evt-${crypto.randomUUID()}`,
-      date: new Date().toISOString(),
-      title: e.title || 'Untitled Event',
-      category: (e.category as Category) || 'Legislative',
-      direction: (e.direction as 1 | -1) ?? 1,
-      magnitude: Number(e.magnitude ?? 1),
-      confidence: Number(e.confidence ?? 0.8),
-      url: e.url,
-    }
-    setEvents(prev => [item, ...prev])
-  }
-
-  function mergeEvents(prev: EventItem[], incoming: EventItem[]) {
-    const map = new Map(prev.map(x => [x.id, x]))
-    for (const e of incoming) map.set(e.id, e)
-    return Array.from(map.values()).sort((a, b) => +new Date(b.date) - +new Date(a.date))
-  }
-
-  function handleImport() {
-    try {
-      const arr = JSON.parse(importText)
-      if (Array.isArray(arr)) setEvents(prev => mergeEvents(prev, arr))
-      setImportText('')
-    } catch {
-      alert('Invalid JSON. Expect an array of EventItem objects.')
-    }
-  }
-
-  return (
-    <div className="space-y-8">
-      {/* Category Gauges */}
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Category Gauges</h2>
-        <div className="grid md:grid-cols-3 gap-4">
-          {CATEGORIES.map((c) => (
-            <Card key={c}>
-              <CardHeader className="py-3"><CardTitle className="text-base">{c}</CardTitle></CardHeader>
-              <CardContent><Gauge value={categoryScores[c]} /></CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
-
-      {/* Ledger */}
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Event Ledger</h2>
-        <div className="space-y-3">
-          {events.map(e => <EventRow key={e.id} e={e} detailed />)}
-        </div>
-      </section>
-
-      {/* Add / Import */}
-      <section className="grid md:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader className="py-3"><CardTitle>Add Event (Quick)</CardTitle></CardHeader>
-          <CardContent className="grid md:grid-cols-6 gap-3 items-end">
-            <div className="md:col-span-2">
-              <label className="text-sm">Title</label>
-              <Input value={qa.title as string} onChange={e => setQa({ ...qa, title: e.target.value })} placeholder="e.g., Court blocks voter suppression bill" />
-            </div>
-            <div>
-              <label className="text-sm">Category</label>
-              <select className="w-full border rounded-md h-10 px-2" value={qa.category as string} onChange={e => setQa({ ...qa, category: e.target.value as Category })}>
-                {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
-              </select>
-            </div>
-            <div>
-              <label className="text-sm">Direction</label>
-              <select className="w-full border rounded-md h-10 px-2" value={qa.direction as number} onChange={e => setQa({ ...qa, direction: Number(e.target.value) as 1 | -1 })}>
-                <option value={1}>Towards Democracy (+)</option>
-                <option value={-1}>Towards Autocracy (-)</option>
-              </select>
-            </div>
-            <div>
-              <label className="text-sm">Magnitude</label>
-              <Input type="number" step="0.1" value={qa.magnitude as number} onChange={e => setQa({ ...qa, magnitude: Number(e.target.value) })} />
-            </div>
-            <div>
-              <label className="text-sm">Confidence</label>
-              <Input type="number" step="0.05" value={qa.confidence as number} onChange={e => setQa({ ...qa, confidence: Number(e.target.value) })} />
-            </div>
-            <Button className="md:col-span-1" onClick={() => addEvent(qa)}>Add</Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="py-3"><CardTitle>Import Events (JSON)</CardTitle></CardHeader>
-          <CardContent className="space-y-2">
-            <Textarea rows={8} value={importText} onChange={(e) => setImportText(e.target.value)} placeholder={exampleJSON} />
-            <div className="flex gap-2">
-              <Button onClick={handleImport}><RefreshCw className="w-4 h-4 mr-2"/>Import</Button>
-              <Button variant="secondary" onClick={() => setImportText(exampleJSON)}>Load Example</Button>
-            </div>
-          </CardContent>
-        </Card>
-      </section>
-    </div>
-  )
-}
-
-function WeightsPanel({ weights, setWeights }: { weights: Record<Category, number>; setWeights: React.Dispatch<React.SetStateAction<Record<Category, number>>> }) {
-  return (
-    <Card>
-      <CardHeader className="py-3"><CardTitle>Category Weights</CardTitle></CardHeader>
-      <CardContent className="grid md:grid-cols-2 gap-4">
-        {CATEGORIES.map((c) => (
-          <div key={c} className="p-3 rounded-xl bg-gray-50">
-            <div className="flex items-center justify-between mb-2">
-              <span className="font-medium">{c}</span>
-              <span className="text-sm opacity-70">{weights[c].toFixed(2)}</span>
-            </div>
-            <Slider value={[weights[c]]} min={0} max={3} step={0.05} onValueChange={(v) => setWeights(w => ({ ...w, [c]: v[0] }))} />
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  )
-}
-
-function Gauge({ value }: { value: number }) {
-  return (
-    <div className="space-y-2">
-      <div className="text-2xl font-semibold">{value.toFixed(1)}</div>
-      <div className="relative h-3 rounded-full bg-gray-100 overflow-hidden">
-        <div className="absolute inset-0 flex"><div className="w-1/2 h-full bg-red-50" /><div className="w-1/2 h-full bg-green-50" /></div>
-        <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
-        <motion.div className="absolute top-0 h-full bg-black" initial={{ x: '50%', width: '2%' }} animate={{ x: `${50 + (value/2)}%` }} transition={{ type: 'spring', stiffness: 120, damping: 20 }} style={{ width: '2%' }} />
-      </div>
-    </div>
-  )
-}
-
-function EventRow({ e, detailed = false }: { e: EventItem; detailed?: boolean }) {
-  const Icon = e.direction === 1 ? ArrowUpRight : ArrowDownRight
-  return (
-    <div className={`p-3 rounded-xl border ${e.direction===1 ? 'bg-green-50/40 border-green-200' : 'bg-red-50/40 border-red-200'}`}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="font-medium truncate">{e.title}</div>
-          <div className="text-xs opacity-70">{new Date(e.date).toLocaleString()} · {e.category}</div>
-          {detailed && e.summary && <div className="text-sm mt-1">{e.summary}</div>}
-          {detailed && e.url && <a className="text-sm underline" href={e.url} target="_blank" rel="noreferrer">Source</a>}
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <div className={`px-2 py-1 rounded-full text-xs font-medium border flex items-center gap-1 ${e.direction===1 ? 'bg-green-50 border-green-300' : 'bg-red-50 border-red-300'}`}>
-            <Icon className="w-3 h-3" />
-            {e.direction===1 ? '+ ' : '- '}{e.magnitude.toFixed(1)} · conf {Math.round(e.confidence*100)}%
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const exampleJSON = `[
-  {"id":"ext-001","date":"${new Date().toISOString()}","title":"Independent commission adopts fair maps","category":"Elections","direction":1,"magnitude":3.0,"confidence":0.9,"url":"https://example.com/source"},
-  {"id":"ext-002","date":"${new Date().toISOString()}","title":"Court stays injunction; restrictive law reinstated","category":"Rights & Liberties","direction":-1,"magnitude":2.0,"confidence":0.85}
-]`
-

--- a/src/components/tracker/deep-dive.tsx
+++ b/src/components/tracker/deep-dive.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import React, { useMemo, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { RefreshCw } from 'lucide-react'
+import {
+  CATEGORIES,
+  CATEGORY_META,
+  Category,
+  CategoryScores,
+  EventItem,
+  computeEventStats,
+  exampleImportPayload,
+} from '@/lib/democracy'
+import { Gauge } from './gauge'
+import { EventRow } from './event-row'
+
+type DeepDiveProps = {
+  events: EventItem[]
+  setEvents: React.Dispatch<React.SetStateAction<EventItem[]>>
+  categoryScores: CategoryScores
+}
+
+type EventDraft = Pick<EventItem, 'title' | 'category' | 'direction' | 'magnitude' | 'confidence' | 'url'>
+
+type DirectionFilter = 'all' | 'positive' | 'negative'
+
+type CategoryFilter = Category | 'All'
+
+export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
+  const [draft, setDraft] = useState<EventDraft>({
+    title: '',
+    category: 'Legislative',
+    direction: 1,
+    magnitude: 1,
+    confidence: 0.8,
+    url: '',
+  })
+  const [importText, setImportText] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('All')
+  const [directionFilter, setDirectionFilter] = useState<DirectionFilter>('all')
+  const [search, setSearch] = useState('')
+
+  const filteredEvents = useMemo(() => {
+    return events.filter(event => {
+      if (categoryFilter !== 'All' && event.category !== categoryFilter) return false
+      if (directionFilter === 'positive' && event.direction !== 1) return false
+      if (directionFilter === 'negative' && event.direction !== -1) return false
+      if (search && !`${event.title} ${event.summary ?? ''}`.toLowerCase().includes(search.toLowerCase())) return false
+      return true
+    })
+  }, [events, categoryFilter, directionFilter, search])
+
+  const filteredStats = useMemo(() => computeEventStats(filteredEvents), [filteredEvents])
+
+  function addEvent(partial: Partial<EventDraft>) {
+    const event: EventItem = {
+      id: `evt-${crypto.randomUUID()}`,
+      date: new Date().toISOString(),
+      title: partial.title?.trim() || 'Untitled Event',
+      category: (partial.category as Category) || 'Legislative',
+      direction: (partial.direction as 1 | -1) ?? 1,
+      magnitude: Number(partial.magnitude ?? 1),
+      confidence: Number(partial.confidence ?? 0.8),
+      url: partial.url?.trim() || undefined,
+    }
+
+    setEvents(prev => [event, ...prev])
+    setDraft(d => ({ ...d, title: '', url: '' }))
+  }
+
+  function mergeEvents(previous: EventItem[], incoming: EventItem[]) {
+    const map = new Map(previous.map(event => [event.id, event]))
+    for (const event of incoming) map.set(event.id, event)
+    return Array.from(map.values()).sort((a, b) => +new Date(b.date) - +new Date(a.date))
+  }
+
+  function handleImport() {
+    try {
+      const parsed = JSON.parse(importText)
+      if (Array.isArray(parsed)) {
+        setEvents(previous => mergeEvents(previous, parsed))
+      }
+      setImportText('')
+    } catch (err) {
+      console.error('Failed to import events', err)
+      alert('Invalid JSON. Expect an array of EventItem objects.')
+    }
+  }
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold">Category Gauges</h2>
+          <p className="text-sm text-muted-foreground">
+            Scores reflect decayed, confidence-weighted impacts over the past year.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-3">
+          {CATEGORIES.map(category => (
+            <Card key={category}>
+              <CardHeader className="py-3">
+                <CardTitle className="text-base">{category}</CardTitle>
+                <p className="text-xs text-muted-foreground">
+                  {CATEGORY_META[category].description}
+                </p>
+              </CardHeader>
+              <CardContent>
+                <Gauge value={categoryScores[category]} accentColor={CATEGORY_META[category].accentColor} />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-semibold">Event Ledger</h2>
+            <p className="text-sm text-muted-foreground">
+              Filter, search, and review the most recent developments.
+            </p>
+          </div>
+          <div className="grid gap-2 text-sm md:grid-cols-3">
+            <select
+              className="h-10 rounded-md border bg-background px-3"
+              value={categoryFilter}
+              onChange={event => setCategoryFilter(event.target.value as CategoryFilter)}
+            >
+              <option value="All">All categories</option>
+              {CATEGORIES.map(category => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+            <select
+              className="h-10 rounded-md border bg-background px-3"
+              value={directionFilter}
+              onChange={event => setDirectionFilter(event.target.value as DirectionFilter)}
+            >
+              <option value="all">All directions</option>
+              <option value="positive">Pro-democracy</option>
+              <option value="negative">Anti-democracy</option>
+            </select>
+            <Input placeholder="Search events" value={search} onChange={event => setSearch(event.target.value)} />
+          </div>
+        </div>
+
+        <Card>
+          <CardContent className="grid gap-4 py-4 md:grid-cols-4">
+            <LedgerStat label="Visible events" value={filteredStats.total.toString()} />
+            <LedgerStat label="Positive" value={filteredStats.positive.toString()} tone="positive" />
+            <LedgerStat label="Negative" value={filteredStats.negative.toString()} tone="negative" />
+            <LedgerStat
+              label="Net impact"
+              value={`${filteredStats.netImpact >= 0 ? '+' : ''}${filteredStats.netImpact.toFixed(2)}`}
+              tone={filteredStats.netImpact >= 0 ? 'positive' : 'negative'}
+            />
+          </CardContent>
+        </Card>
+
+        <div className="space-y-3">
+          {filteredEvents.length === 0 && (
+            <div className="rounded-xl border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+              No events match your filters yet.
+            </div>
+          )}
+          {filteredEvents.map(event => (
+            <EventRow key={event.id} event={event} detailed />
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3">
+            <CardTitle>Add Event (Quick)</CardTitle>
+          </CardHeader>
+          <CardContent className="grid items-end gap-3 md:grid-cols-6">
+            <div className="md:col-span-2">
+              <label className="text-sm">Title</label>
+              <Input
+                value={draft.title}
+                onChange={event => setDraft(previous => ({ ...previous, title: event.target.value }))}
+                placeholder="e.g., Court blocks voter suppression bill"
+              />
+            </div>
+            <div>
+              <label className="text-sm">Category</label>
+              <select
+                className="h-10 w-full rounded-md border px-2"
+                value={draft.category}
+                onChange={event => setDraft(previous => ({ ...previous, category: event.target.value as Category }))}
+              >
+                {CATEGORIES.map(category => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-sm">Direction</label>
+              <select
+                className="h-10 w-full rounded-md border px-2"
+                value={draft.direction}
+                onChange={event =>
+                  setDraft(previous => ({ ...previous, direction: Number(event.target.value) as 1 | -1 }))
+                }
+              >
+                <option value={1}>Towards Democracy (+)</option>
+                <option value={-1}>Towards Autocracy (-)</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm">Magnitude</label>
+              <Input
+                type="number"
+                step="0.1"
+                value={draft.magnitude}
+                onChange={event => setDraft(previous => ({ ...previous, magnitude: Number(event.target.value) }))}
+              />
+            </div>
+            <div>
+              <label className="text-sm">Confidence</label>
+              <Input
+                type="number"
+                step="0.05"
+                value={draft.confidence}
+                onChange={event => setDraft(previous => ({ ...previous, confidence: Number(event.target.value) }))}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label className="text-sm">Source URL</label>
+              <Input
+                value={draft.url}
+                onChange={event => setDraft(previous => ({ ...previous, url: event.target.value }))}
+                placeholder="https://example.com/source"
+              />
+            </div>
+            <Button className="md:col-span-1" onClick={() => addEvent(draft)}>
+              Add
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3">
+            <CardTitle>Import Events (JSON)</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Textarea
+              rows={8}
+              value={importText}
+              onChange={event => setImportText(event.target.value)}
+              placeholder={exampleImportPayload}
+            />
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={handleImport}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Import
+              </Button>
+              <Button variant="secondary" onClick={() => setImportText(exampleImportPayload)}>
+                Load Example
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}
+
+function LedgerStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string
+  tone?: 'positive' | 'negative'
+}) {
+  const toneClasses =
+    tone === 'positive'
+      ? 'text-emerald-600'
+      : tone === 'negative'
+        ? 'text-rose-600'
+        : 'text-foreground'
+
+  return (
+    <div className="space-y-1">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={`text-lg font-semibold ${toneClasses}`}>{value}</div>
+    </div>
+  )
+}

--- a/src/components/tracker/event-row.tsx
+++ b/src/components/tracker/event-row.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { ArrowDownRight, ArrowUpRight } from 'lucide-react'
+import { motion } from 'framer-motion'
+import { CATEGORY_META, EventItem } from '@/lib/democracy'
+
+export function EventRow({ event, detailed = false }: { event: EventItem; detailed?: boolean }) {
+  const Icon = event.direction === 1 ? ArrowUpRight : ArrowDownRight
+  const directionLabel = event.direction === 1 ? 'Towards Democracy' : 'Towards Autocracy'
+  const impactScore = event.magnitude * event.confidence
+  const accentColor = CATEGORY_META[event.category].accentColor
+
+  return (
+    <div
+      className={`group relative overflow-hidden rounded-xl border transition-colors ${
+        event.direction === 1 ? 'border-green-200 bg-green-50/40' : 'border-red-200 bg-red-50/40'
+      }`}
+    >
+      <motion.div
+        className="absolute inset-y-0 left-0 w-1"
+        style={{ backgroundColor: accentColor }}
+        layoutId={`${event.category}-accent`}
+      />
+      <div className="p-3 md:p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="truncate font-medium">{event.title}</div>
+            <div className="text-xs text-muted-foreground">
+              {new Date(event.date).toLocaleString()} · {event.category}
+            </div>
+            {detailed && event.summary && <div className="text-sm text-muted-foreground">{event.summary}</div>}
+            {detailed && event.url && (
+              <a className="text-sm font-medium text-primary underline" href={event.url} target="_blank" rel="noreferrer">
+                Source
+              </a>
+            )}
+          </div>
+          <div className="flex shrink-0 flex-col items-end gap-1 text-right">
+            <div
+              className={`flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium ${
+                event.direction === 1 ? 'border-green-300 bg-green-100/70 text-green-900' : 'border-red-300 bg-red-100/70 text-red-900'
+              }`}
+            >
+              <Icon className="h-3 w-3" />
+              {event.direction === 1 ? '+' : '-'}
+              {event.magnitude.toFixed(1)} · conf {Math.round(event.confidence * 100)}%
+            </div>
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{directionLabel}</div>
+            <div className="text-xs text-muted-foreground">
+              Impact score <span className="font-semibold text-foreground">{impactScore.toFixed(2)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/tracker/gauge.tsx
+++ b/src/components/tracker/gauge.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { motion } from 'framer-motion'
+
+export function Gauge({ value, accentColor }: { value: number; accentColor: string }) {
+  return (
+    <div className="space-y-2">
+      <div className="text-2xl font-semibold">{value.toFixed(1)}</div>
+      <div className="relative h-3 overflow-hidden rounded-full bg-gray-100">
+        <div className="absolute inset-0 flex">
+          <div className="h-full w-1/2 bg-red-50" />
+          <div className="h-full w-1/2 bg-green-50" />
+        </div>
+        <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
+        <motion.div
+          className="absolute top-0 h-full"
+          style={{ backgroundColor: accentColor, width: '4%' }}
+          initial={{ x: '50%' }}
+          animate={{ x: `${50 + value / 2}%` }}
+          transition={{ type: 'spring', stiffness: 120, damping: 20 }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/tracker/share-card.tsx
+++ b/src/components/tracker/share-card.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useMemo } from 'react'
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts'
+import {
+  CATEGORIES,
+  CATEGORY_META,
+  CategoryScores,
+  EventItem,
+  ScoreHistoryPoint,
+  computeEventStats,
+} from '@/lib/democracy'
+import { EventRow } from './event-row'
+
+type ShareCardProps = {
+  index: number
+  history: ScoreHistoryPoint[]
+  categoryScores: CategoryScores
+  events: EventItem[]
+}
+
+export function ShareCard({ index, history, categoryScores, events }: ShareCardProps) {
+  const stats = useMemo(() => computeEventStats(events), [events])
+  const historyData = history.map(point => ({
+    t: new Date(point.ts).toLocaleTimeString(),
+    v: point.value,
+  }))
+
+  return (
+    <div className="grid gap-6 md:grid-cols-5">
+      <div className="space-y-4 md:col-span-3">
+        <div className="space-y-3">
+          <h1 className="text-2xl font-bold md:text-3xl">Today’s Index: {index.toFixed(1)}</h1>
+          <div className="relative h-16 overflow-hidden rounded-2xl bg-gray-100">
+            <div className="absolute inset-0 flex">
+              <div className="h-full w-1/2 bg-red-50" />
+              <div className="h-full w-1/2 bg-green-50" />
+            </div>
+            <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
+            <motion.div
+              className="absolute top-0 h-full w-1.5 rounded bg-foreground"
+              initial={{ x: '50%' }}
+              animate={{ x: `${50 + index / 2}%` }}
+              transition={{ type: 'spring', stiffness: 120, damping: 20 }}
+            />
+            <div className="absolute inset-0 flex items-center justify-between px-3 text-xs font-medium">
+              <span>-100 Autocracy</span>
+              <span>0</span>
+              <span>+100 Democracy</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-3 rounded-2xl border bg-muted/40 p-4 text-sm md:grid-cols-3">
+          <StatBlock label="Total events" value={stats.total.toString()} />
+          <StatBlock
+            label="Net impact"
+            value={`${stats.netImpact >= 0 ? '+' : ''}${stats.netImpact.toFixed(2)}`}
+            tone={stats.netImpact >= 0 ? 'positive' : 'negative'}
+          />
+          <StatBlock
+            label="Avg. confidence"
+            value={`${Math.round(stats.averageConfidence * 100)}%`}
+          />
+          <StatBlock label="Positive" value={stats.positive.toString()} tone="positive" />
+          <StatBlock label="Negative" value={stats.negative.toString()} tone="negative" />
+          <StatBlock
+            label="Last update"
+            value={stats.latestEventDate ? new Date(stats.latestEventDate).toLocaleString() : '—'}
+          />
+        </div>
+
+        <div className="h-24">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={historyData} margin={{ top: 8, bottom: 0, left: 0, right: 0 }}>
+              <XAxis dataKey="t" hide />
+              <YAxis domain={[-100, 100]} hide />
+              <Tooltip
+                formatter={(value: number | string) =>
+                  typeof value === 'number' ? value.toFixed(1) : value
+                }
+              />
+              <Line type="monotone" dataKey="v" dot={false} strokeWidth={2} stroke="#111827" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className="space-y-4 md:col-span-2">
+        <Card>
+          <CardHeader className="py-3">
+            <CardTitle className="text-sm">Category Snapshot</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-3">
+            {CATEGORIES.map(category => (
+              <div key={category} className="text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">{category}</span>
+                  <span className="font-medium">{categoryScores[category].toFixed(0)}</span>
+                </div>
+                <div className="relative h-2 overflow-hidden rounded-full bg-gray-100">
+                  <div className="absolute inset-0 flex">
+                    <div className="h-full w-1/2 bg-red-50" />
+                    <div className="h-full w-1/2 bg-green-50" />
+                  </div>
+                  <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
+                  <motion.div
+                    className="absolute top-0 h-full"
+                    style={{ backgroundColor: CATEGORY_META[category].accentColor, width: '3%' }}
+                    initial={{ x: '50%' }}
+                    animate={{ x: `${50 + categoryScores[category] / 2}%` }}
+                    transition={{ type: 'spring', stiffness: 120, damping: 20 }}
+                  />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3">
+            <CardTitle className="text-sm">Today’s Moves</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {events.slice(0, 3).map(event => (
+              <EventRow key={event.id} event={event} />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function StatBlock({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string
+  tone?: 'positive' | 'negative'
+}) {
+  const toneClasses =
+    tone === 'positive'
+      ? 'text-emerald-600'
+      : tone === 'negative'
+        ? 'text-rose-600'
+        : 'text-foreground'
+
+  return (
+    <div className="space-y-1">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={`text-lg font-semibold ${toneClasses}`}>{value}</div>
+    </div>
+  )
+}

--- a/src/components/tracker/weights-panel.tsx
+++ b/src/components/tracker/weights-panel.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMemo } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Slider } from '@/components/ui/slider'
+import { Button } from '@/components/ui/button'
+import { CATEGORIES, CategoryWeights, createDefaultWeights } from '@/lib/democracy'
+
+type WeightsPanelProps = {
+  weights: CategoryWeights
+  setWeights: React.Dispatch<React.SetStateAction<CategoryWeights>>
+}
+
+export function WeightsPanel({ weights, setWeights }: WeightsPanelProps) {
+  const totalWeight = useMemo(() => Object.values(weights).reduce((acc, value) => acc + value, 0), [weights])
+
+  function handleReset() {
+    setWeights(createDefaultWeights())
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-wrap items-center justify-between gap-3 py-3">
+        <CardTitle>Category Weights</CardTitle>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>Total weight:</span>
+          <span className="font-semibold text-foreground">{totalWeight.toFixed(2)}</span>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-4 md:grid-cols-2">
+        {CATEGORIES.map(category => {
+          const share = totalWeight > 0 ? (weights[category] / totalWeight) * 100 : 0
+          return (
+            <div key={category} className="space-y-2 rounded-xl bg-muted/40 p-3">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{category}</span>
+                <span className="text-sm text-muted-foreground">{weights[category].toFixed(2)}</span>
+              </div>
+              <Slider
+                value={[weights[category]]}
+                min={0}
+                max={3}
+                step={0.05}
+                onValueChange={value => setWeights(previous => ({ ...previous, [category]: value[0] }))}
+              />
+              <div className="text-xs text-muted-foreground">
+                {share.toFixed(0)}% of total influence
+              </div>
+            </div>
+          )
+        })}
+        <Button variant="secondary" onClick={handleReset} className="md:col-span-2">
+          Reset weights
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/democracy.ts
+++ b/src/lib/democracy.ts
@@ -1,0 +1,198 @@
+export const CATEGORIES = [
+  'Legislative',
+  'Executive',
+  'Judicial',
+  'Elections',
+  'Rights & Liberties',
+  'Civil Society',
+  'Political Violence',
+] as const
+
+export type Category = (typeof CATEGORIES)[number]
+export type CategoryScores = Record<Category, number>
+export type CategoryWeights = Record<Category, number>
+export type EventDirection = 1 | -1
+
+export type EventItem = {
+  id: string
+  date: string // ISO
+  title: string
+  summary?: string
+  url?: string
+  category: Category
+  direction: EventDirection // +1 = towards democracy, -1 = towards autocracy
+  magnitude: number // 0.5..5 typical; can exceed
+  confidence: number // 0..1
+}
+
+export type ScoreHistoryPoint = { ts: number; value: number }
+
+export const CATEGORY_META: Record<
+  Category,
+  {
+    description: string
+    accentColor: string
+  }
+> = {
+  Legislative: {
+    description: 'Law-making, oversight, and checks on executive power.',
+    accentColor: '#6366f1',
+  },
+  Executive: {
+    description: 'Administrative actions, transparency, and rule implementation.',
+    accentColor: '#0ea5e9',
+  },
+  Judicial: {
+    description: 'Courts, judicial independence, and rule-of-law decisions.',
+    accentColor: '#8b5cf6',
+  },
+  Elections: {
+    description: 'Voting access, election integrity, and representation.',
+    accentColor: '#22c55e',
+  },
+  'Rights & Liberties': {
+    description: 'Civil liberties, minority protections, and free expression.',
+    accentColor: '#f97316',
+  },
+  'Civil Society': {
+    description: 'Media, organizing, and civic participation.',
+    accentColor: '#ec4899',
+  },
+  'Political Violence': {
+    description: 'Political intimidation, violence, and security of participants.',
+    accentColor: '#ef4444',
+  },
+}
+
+export function createDefaultWeights(): CategoryWeights {
+  return Object.fromEntries(CATEGORIES.map(category => [category, 1])) as CategoryWeights
+}
+
+export function computeCategoryScores(events: EventItem[], now = new Date()): CategoryScores {
+  const halfLifeDays = 365
+  const lambda = Math.log(2) / halfLifeDays
+  const base = Object.fromEntries(CATEGORIES.map(category => [category, 0])) as CategoryScores
+
+  for (const event of events) {
+    const ageDays = Math.max(0, (now.getTime() - new Date(event.date).getTime()) / (1000 * 60 * 60 * 24))
+    const decay = Math.exp(-lambda * ageDays)
+    const signedImpact = event.direction * event.magnitude * event.confidence * decay
+    base[event.category] += signedImpact
+  }
+
+  const normalized: CategoryScores = { ...base }
+  for (const category of CATEGORIES) {
+    normalized[category] = Math.tanh(base[category] / 10) * 100
+  }
+
+  return normalized
+}
+
+export function weightedIndex(categoryScores: CategoryScores, weights: CategoryWeights) {
+  const totalWeight = Object.values(weights).reduce((acc, value) => acc + value, 0) || 1
+  const sum = (CATEGORIES as readonly Category[]).reduce(
+    (acc, category) => acc + categoryScores[category] * weights[category],
+    0,
+  )
+
+  return sum / totalWeight
+}
+
+export type EventStats = {
+  total: number
+  positive: number
+  negative: number
+  netImpact: number
+  averageConfidence: number
+  latestEventDate?: string
+}
+
+export function computeEventStats(events: EventItem[]): EventStats {
+  if (!events.length) {
+    return { total: 0, positive: 0, negative: 0, netImpact: 0, averageConfidence: 0, latestEventDate: undefined }
+  }
+
+  let positive = 0
+  let negative = 0
+  let netImpact = 0
+  let confidenceSum = 0
+  let latestEventDate: string | undefined
+
+  for (const event of events) {
+    if (event.direction === 1) positive += 1
+    else negative += 1
+
+    netImpact += event.direction * event.magnitude * event.confidence
+    confidenceSum += event.confidence
+
+    if (!latestEventDate || new Date(event.date) > new Date(latestEventDate)) {
+      latestEventDate = event.date
+    }
+  }
+
+  return {
+    total: events.length,
+    positive,
+    negative,
+    netImpact,
+    averageConfidence: confidenceSum / events.length,
+    latestEventDate,
+  }
+}
+
+export const seedEvents: EventItem[] = [
+  {
+    id: 'seed-1',
+    date: new Date(Date.now() - 3 * 24 * 3600 * 1000).toISOString(),
+    title: 'Court curtails gerrymandered map',
+    category: 'Elections',
+    direction: 1,
+    magnitude: 2.5,
+    confidence: 0.9,
+    url: '#',
+  },
+  {
+    id: 'seed-2',
+    date: new Date(Date.now() - 1 * 24 * 3600 * 1000).toISOString(),
+    title: 'Legislature advances voter ID expansion',
+    category: 'Elections',
+    direction: -1,
+    magnitude: 2.0,
+    confidence: 0.8,
+  },
+  {
+    id: 'seed-3',
+    date: new Date().toISOString(),
+    title: 'Peaceful mass protest for press freedom',
+    category: 'Civil Society',
+    direction: 1,
+    magnitude: 1.2,
+    confidence: 0.7,
+  },
+]
+
+export const exampleImportPayload = JSON.stringify(
+  [
+    {
+      id: 'ext-001',
+      date: new Date().toISOString(),
+      title: 'Independent commission adopts fair maps',
+      category: 'Elections',
+      direction: 1,
+      magnitude: 3,
+      confidence: 0.9,
+      url: 'https://example.com/source',
+    },
+    {
+      id: 'ext-002',
+      date: new Date().toISOString(),
+      title: 'Court stays injunction; restrictive law reinstated',
+      category: 'Rights & Liberties',
+      direction: -1,
+      magnitude: 2,
+      confidence: 0.85,
+    },
+  ],
+  null,
+  2,
+)


### PR DESCRIPTION
## Summary
- centralize democracy tracker types, scoring helpers, seed data, and category metadata in a reusable lib module
- split the monolithic page into dedicated tracker components with richer share card stats, ledger filters/search, and improved weight controls
- ignore generated docs output in eslint so linting focuses on source files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb684eac348332b355ceffc369a746