### PR TITLE
Fix hydration mismatch in import placeholder

### DIFF
--- a/src/lib/democracy.ts
+++ b/src/lib/democracy.ts
@@ -171,28 +171,26 @@ export const seedEvents: EventItem[] = [
   },
 ]
 
-export const exampleImportPayload = JSON.stringify(
-  [
-    {
-      id: 'ext-001',
-      date: new Date().toISOString(),
-      title: 'Independent commission adopts fair maps',
-      category: 'Elections',
-      direction: 1,
-      magnitude: 3,
-      confidence: 0.9,
-      url: 'https://example.com/source',
-    },
-    {
-      id: 'ext-002',
-      date: new Date().toISOString(),
-      title: 'Court stays injunction; restrictive law reinstated',
-      category: 'Rights & Liberties',
-      direction: -1,
-      magnitude: 2,
-      confidence: 0.85,
-    },
-  ],
-  null,
-  2,
-)
+const EXAMPLE_IMPORT_EVENTS: EventItem[] = [
+  {
+    id: 'ext-001',
+    date: '2024-03-01T00:00:00.000Z',
+    title: 'Independent commission adopts fair maps',
+    category: 'Elections',
+    direction: 1,
+    magnitude: 3,
+    confidence: 0.9,
+    url: 'https://example.com/source',
+  },
+  {
+    id: 'ext-002',
+    date: '2024-02-15T00:00:00.000Z',
+    title: 'Court stays injunction; restrictive law reinstated',
+    category: 'Rights & Liberties',
+    direction: -1,
+    magnitude: 2,
+    confidence: 0.85,
+  },
+]
+
+export const exampleImportPayload = JSON.stringify(EXAMPLE_IMPORT_EVENTS, null, 2)


### PR DESCRIPTION
## Summary
- replace dynamically generated example import payload timestamps with stable sample data to keep server and client renders in sync
- export the formatted JSON string from a shared constant to ensure deterministic placeholders during hydration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5f757a6c4833283e659df6c93a618