### PR TITLE
Convert seed events to runtime factory and add Jest CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --ci --reporters=default --reporters=jest-junit

--- a/__tests__/democracy.test.ts
+++ b/__tests__/democracy.test.ts
@@ -1,0 +1,20 @@
+import { getSeedEvents, type EventItem } from '@/lib/democracy'
+
+describe('getSeedEvents', () => {
+  it('returns an array of 3 valid EventItems with ISO dates', () => {
+    const events = getSeedEvents()
+    expect(events).toHaveLength(3)
+
+    for (const event of events) {
+      expect(event).toHaveProperty('id')
+      expect(event).toHaveProperty('title')
+      expect(event).toHaveProperty('category')
+      expect(event).toHaveProperty('direction')
+      expect(event).toHaveProperty('magnitude')
+      expect(event).toHaveProperty('confidence')
+
+      const parsedDate = new Date((event as EventItem).date)
+      expect(() => parsedDate.toISOString()).not.toThrow()
+    }
+  })
+})

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
+    "test": "jest",
     "build:pages": "next build && next export",
     "deploy:pages": "rm -rf docs && mkdir -p docs && cp -r out/* docs/ && touch docs/.nojekyll"
   },
@@ -26,13 +27,16 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@types/jest": "^29",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
+    "jest": "^29",
     "tailwindcss": "^4",
+    "ts-jest": "^29",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,17 +14,21 @@ import {
   ScoreHistoryPoint,
   computeCategoryScores,
   createDefaultWeights,
-  seedEvents,
+  getSeedEvents,
   weightedIndex,
 } from '@/lib/democracy'
 
 export default function DemocracyTracker() {
-  const [events, setEvents] = useState<EventItem[]>(seedEvents)
+  const [events, setEvents] = useState<EventItem[]>([])
   const [weights, setWeights] = useState<CategoryWeights>(() => createDefaultWeights())
   const [history, setHistory] = useState<ScoreHistoryPoint[]>([])
 
   const categoryScores = useMemo<CategoryScores>(() => computeCategoryScores(events), [events])
   const index = useMemo(() => weightedIndex(categoryScores, weights), [categoryScores, weights])
+
+  useEffect(() => {
+    setEvents(getSeedEvents())
+  }, [])
 
   useEffect(() => {
     setHistory(previous => [...previous.slice(-199), { ts: Date.now(), value: index }])

--- a/src/lib/democracy.ts
+++ b/src/lib/democracy.ts
@@ -140,36 +140,38 @@ export function computeEventStats(events: EventItem[]): EventStats {
   }
 }
 
-export const seedEvents: EventItem[] = [
-  {
-    id: 'seed-1',
-    date: new Date(Date.now() - 3 * 24 * 3600 * 1000).toISOString(),
-    title: 'Court curtails gerrymandered map',
-    category: 'Elections',
-    direction: 1,
-    magnitude: 2.5,
-    confidence: 0.9,
-    url: '#',
-  },
-  {
-    id: 'seed-2',
-    date: new Date(Date.now() - 1 * 24 * 3600 * 1000).toISOString(),
-    title: 'Legislature advances voter ID expansion',
-    category: 'Elections',
-    direction: -1,
-    magnitude: 2.0,
-    confidence: 0.8,
-  },
-  {
-    id: 'seed-3',
-    date: new Date().toISOString(),
-    title: 'Peaceful mass protest for press freedom',
-    category: 'Civil Society',
-    direction: 1,
-    magnitude: 1.2,
-    confidence: 0.7,
-  },
-]
+export function getSeedEvents(): EventItem[] {
+  return [
+    {
+      id: 'seed-1',
+      date: new Date(Date.now() - 3 * 24 * 3600 * 1000).toISOString(),
+      title: 'Court curtails gerrymandered map',
+      category: 'Elections',
+      direction: 1,
+      magnitude: 2.5,
+      confidence: 0.9,
+      url: '#',
+    },
+    {
+      id: 'seed-2',
+      date: new Date(Date.now() - 1 * 24 * 3600 * 1000).toISOString(),
+      title: 'Legislature advances voter ID expansion',
+      category: 'Elections',
+      direction: -1,
+      magnitude: 2.0,
+      confidence: 0.8,
+    },
+    {
+      id: 'seed-3',
+      date: new Date().toISOString(),
+      title: 'Peaceful mass protest for press freedom',
+      category: 'Civil Society',
+      direction: 1,
+      magnitude: 1.2,
+      confidence: 0.7,
+    },
+  ]
+}
 
 const EXAMPLE_IMPORT_EVENTS: EventItem[] = [
   {


### PR DESCRIPTION
## Summary
- replace the static seedEvents export with a getSeedEvents factory that generates fresh timestamps
- initialize the tracker page with an effect-driven seed and cover it with a new Jest unit test
- add Jest configuration and a CI workflow to run the test suite on pushes and pull requests

## Testing
- npm test *(fails locally: Jest binary unavailable in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f9fc9fd083328cd4cce15ab1602e