### PR TITLE
Tighten Democracy Tracker layout spacing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,7 +105,7 @@ export default function DemocracyTracker() {
   return (
     <div className="min-h-screen bg-white">
       <div className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3">
+        <div className="mx-auto flex max-w-4xl items-center justify-between gap-2 px-4 py-2">
           <div className="text-lg font-semibold">U.S. Democracy Tracker</div>
           {/* Hydration-safe time display */}
           <div className="flex items-center gap-2 text-xs opacity-70">
@@ -120,13 +120,13 @@ export default function DemocracyTracker() {
         </div>
       </div>
 
-      <section className="mx-auto max-w-5xl px-4 py-6">
-        <div ref={cardRef} className="rounded-3xl border bg-white p-5 shadow-sm md:p-6">
+      <section className="mx-auto max-w-4xl px-4 py-4">
+        <div ref={cardRef} className="rounded-2xl border bg-white p-4 shadow-sm md:p-5">
           <ShareCard index={index} history={history} categoryScores={categoryScores} events={events} />
         </div>
       </section>
 
-      <main className="mx-auto max-w-5xl space-y-8 px-4 pb-16">
+      <main className="mx-auto max-w-4xl space-y-6 px-4 pb-10">
         <DeepDive events={events} setEvents={setEvents} categoryScores={categoryScores} />
         <WeightsPanel weights={weights} setWeights={setWeights} />
       </main>

--- a/src/components/tracker/deep-dive.tsx
+++ b/src/components/tracker/deep-dive.tsx
@@ -92,18 +92,18 @@ export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
   }
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-6">
       <section>
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-xl font-semibold">Category Gauges</h2>
           <p className="text-sm text-muted-foreground">
             Scores reflect decayed, confidence-weighted impacts over the past year.
           </p>
         </div>
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
           {CATEGORIES.map(category => (
             <Card key={category}>
-              <CardHeader className="py-3">
+              <CardHeader className="py-2">
                 <CardTitle className="text-base">{category}</CardTitle>
                 <p className="text-xs text-muted-foreground">
                   {CATEGORY_META[category].description}
@@ -117,8 +117,8 @@ export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
         </div>
       </section>
 
-      <section className="space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
             <h2 className="text-xl font-semibold">Event Ledger</h2>
             <p className="text-sm text-muted-foreground">
@@ -152,7 +152,7 @@ export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
         </div>
 
         <Card>
-          <CardContent className="grid gap-4 py-4 md:grid-cols-4">
+          <CardContent className="grid grid-cols-2 gap-3 py-3 md:grid-cols-4">
             <LedgerStat label="Visible events" value={filteredStats.total.toString()} />
             <LedgerStat label="Positive" value={filteredStats.positive.toString()} tone="positive" />
             <LedgerStat label="Negative" value={filteredStats.negative.toString()} tone="negative" />
@@ -164,9 +164,9 @@ export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
           </CardContent>
         </Card>
 
-        <div className="space-y-3">
+        <div className="space-y-2.5">
           {filteredEvents.length === 0 && (
-            <div className="rounded-xl border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            <div className="rounded-xl border border-dashed bg-muted/30 p-4 text-center text-sm text-muted-foreground">
               No events match your filters yet.
             </div>
           )}
@@ -176,12 +176,12 @@ export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
         </div>
       </section>
 
-      <section className="grid gap-6 md:grid-cols-2">
+      <section className="grid gap-4 md:grid-cols-2">
         <Card>
-          <CardHeader className="py-3">
+          <CardHeader className="py-2">
             <CardTitle>Add Event (Quick)</CardTitle>
           </CardHeader>
-          <CardContent className="grid items-end gap-3 md:grid-cols-6">
+          <CardContent className="grid items-end gap-2 md:grid-cols-6">
             <div className="md:col-span-2">
               <label className="text-sm">Title</label>
               <Input
@@ -250,7 +250,7 @@ export function DeepDive({ events, setEvents, categoryScores }: DeepDiveProps) {
         </Card>
 
         <Card>
-          <CardHeader className="py-3">
+          <CardHeader className="py-2">
             <CardTitle>Import Events (JSON)</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">

--- a/src/components/tracker/weights-panel.tsx
+++ b/src/components/tracker/weights-panel.tsx
@@ -20,14 +20,14 @@ export function WeightsPanel({ weights, setWeights }: WeightsPanelProps) {
 
   return (
     <Card>
-      <CardHeader className="flex flex-wrap items-center justify-between gap-3 py-3">
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2 py-2">
         <CardTitle>Category Weights</CardTitle>
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <span>Total weight:</span>
           <span className="font-semibold text-foreground">{totalWeight.toFixed(2)}</span>
         </div>
       </CardHeader>
-      <CardContent className="grid gap-4 md:grid-cols-2">
+      <CardContent className="grid gap-3 sm:grid-cols-2">
         {CATEGORIES.map(category => {
           const share = totalWeight > 0 ? (weights[category] / totalWeight) * 100 : 0
           return (
@@ -49,7 +49,7 @@ export function WeightsPanel({ weights, setWeights }: WeightsPanelProps) {
             </div>
           )
         })}
-        <Button variant="secondary" onClick={handleReset} className="md:col-span-2">
+        <Button variant="secondary" onClick={handleReset} className="sm:col-span-2">
           Reset weights
         </Button>
       </CardContent>


### PR DESCRIPTION
## Summary
- tighten the home page header, hero card, and main layout spacing to reduce unused whitespace
- compress Deep Dive grids, stats, and forms for a denser data presentation
- switch the weights panel to a tighter two-column layout with reduced padding on small+ screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d600a0882c8332b04f8d94714f15e4