### PR TITLE
Improve sparkline readability

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,7 +80,18 @@ export default function DemocracyTracker() {
 
   // Keep a small sparkline history (client-only)
   useEffect(() => {
-    setHistory((prev) => [...prev.slice(-199), { ts: Date.now(), value: index }])
+    const now = Date.now()
+    setHistory(prev => {
+      const base =
+        prev.length === 0
+          ? Array.from({ length: 60 }, (_, i) => ({
+              ts: now - (59 - i) * 2000,
+              value: index,
+            }))
+          : prev
+
+      return [...base.slice(-199), { ts: now, value: index }]
+    })
   }, [index])
 
   useEffect(() => {

--- a/src/components/tracker/share-card.tsx
+++ b/src/components/tracker/share-card.tsx
@@ -72,9 +72,13 @@ export function ShareCard({ index, history, categoryScores, events }: ShareCardP
           />
         </div>
 
-        <div className="h-16 md:h-20">
+        <div className="h-20">
           <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={historyData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+            <AreaChart
+              data={historyData}
+              margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+              baseValue={0}
+            >
               <XAxis dataKey="ts" hide axisLine={false} tickLine={false} />
               <YAxis domain={[-100, 100]} hide axisLine={false} tickLine={false} />
               <Tooltip


### PR DESCRIPTION
## Summary
- ensure the share card sparkline always anchors to zero by fixing the domain and base value
- seed sparkline history with a short backfill so the chart starts with a visible band

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d60982b1d4833286fedc30490f5aff