### PR TITLE
Enable live polling and hourly ingest automation

### DIFF
--- a/.github/workflows/ingest-hourly.yml
+++ b/.github/workflows/ingest-hourly.yml
@@ -1,0 +1,42 @@
+name: Ingest & Deploy (Hourly)
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm ci
+
+      - name: Ingest
+        env:
+          PROPUBLICA_API_KEY: ${{ secrets.PROPUBLICA_API_KEY }}
+          OPENSTATES_API_KEY: ${{ secrets.OPENSTATES_API_KEY }}
+        run: npm run ingest
+
+      - name: Build & Export
+        run: |
+          npm run build:pages
+          npm run export:pages
+
+      - name: Publish to /docs
+        run: |
+          rm -rf docs && mkdir -p docs && cp -r out/* docs/ && touch docs/.nojekyll
+          git add -A docs
+          git -c user.name="gh-actions" -c user.email="actions@users.noreply.github.com" commit -m "Auto deploy: $(date -u +'%Y-%m-%d %H:%M:%SZ')" || echo "No changes"
+          git push

--- a/src/components/tracker/share-card.tsx
+++ b/src/components/tracker/share-card.tsx
@@ -83,10 +83,10 @@ export function ShareCard({ index, history, categoryScores, events }: ShareCardP
               <YAxis domain={[-100, 100]} hide axisLine={false} tickLine={false} />
               <Tooltip
                 formatter={(value: number | string) =>
-                  typeof value === 'number' ? value.toFixed(1) : value
+                  typeof value === 'number' ? value.toFixed(2) : value
                 }
                 labelFormatter={(ts: number | string) =>
-                  new Date(typeof ts === 'number' ? ts : Number(ts)).toLocaleTimeString()
+                  new Date(typeof ts === 'number' ? ts : Number(ts)).toLocaleString()
                 }
                 cursor={false}
               />

--- a/src/lib/democracy.ts
+++ b/src/lib/democracy.ts
@@ -113,10 +113,26 @@ export function generateIndexSeries(
   const stepMs = stepMinutes * 60 * 1000
   const start = now - daysBack * 24 * 60 * 60 * 1000
   const points: ScoreHistoryPoint[] = []
+
   for (let ts = start; ts <= now; ts += stepMs) {
-    points.push({ ts, value: computeIndexAt(events, weights, new Date(ts)) })
+    const at = new Date(ts)
+    const visible = events.filter(event => new Date(event.date).getTime() <= ts)
+    points.push({ ts, value: computeIndexAt(visible, weights, at) })
   }
+
   return points
+}
+
+export function mergeEvents(previous: EventItem[], incoming: EventItem[]) {
+  const map = new Map(previous.map(event => [event.id, event] as const))
+
+  for (const event of incoming) {
+    map.set(event.id, event)
+  }
+
+  return Array.from(map.values()).sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  )
 }
 
 export type EventStats = {

--- a/src/lib/live-sources.ts
+++ b/src/lib/live-sources.ts
@@ -1,0 +1,97 @@
+import type { EventItem } from '@/lib/democracy'
+
+type CourtListenerOpinion = {
+  id?: string | number
+  date_filed?: string
+  caseName?: string
+  absolute_url?: string
+  citation?: string
+}
+
+type GdeltArticle = {
+  url?: string
+  seendate?: string
+  title?: string
+}
+
+function toISO(input?: string | null) {
+  try {
+    return input ? new Date(input).toISOString() : new Date().toISOString()
+  } catch {
+    return new Date().toISOString()
+  }
+}
+
+export async function fetchCourtListenerLive(): Promise<EventItem[]> {
+  const url =
+    'https://www.courtlistener.com/api/rest/v3/opinions/?search=voting%20OR%20election%20OR%20%22press%20freedom%22&order_by=-dateFiled&docket_court__jurisdiction=F'
+  const response = await fetch(url, { cache: 'no-store' })
+  if (!response.ok) return []
+  const payload = await response.json()
+  const results = Array.isArray(payload?.results) ? payload.results : []
+
+  return results.map(opinionRaw => {
+    const opinion =
+      typeof opinionRaw === 'object' && opinionRaw !== null ? (opinionRaw as CourtListenerOpinion) : {}
+
+    const date = toISO(typeof opinion.date_filed === 'string' ? opinion.date_filed : undefined)
+    const title = typeof opinion.caseName === 'string' ? opinion.caseName : 'Court opinion'
+    const path = typeof opinion.absolute_url === 'string' ? opinion.absolute_url : undefined
+    const summaryText = `${title} ${typeof opinion.citation === 'string' ? opinion.citation : ''}`
+    const direction: 1 | -1 = /protect|expand|enjoin|strike/i.test(summaryText) ? 1 : -1
+
+    return {
+      id: `cl-${String(opinion.id ?? path ?? date)}`,
+      date,
+      title,
+      url: path ? `https://www.courtlistener.com${path}` : undefined,
+      category: 'Judicial',
+      direction,
+      magnitude: 3,
+      confidence: 0.9,
+    }
+  })
+}
+
+export async function fetchGdeltLive(): Promise<EventItem[]> {
+  const url =
+    'https://api.gdeltproject.org/api/v2/doc/doc?query=protest%20OR%20%22press%20freedom%22%20sourcecountry:US&mode=ArtList&format=json&maxrecords=50'
+  const response = await fetch(url, { cache: 'no-store' })
+  if (!response.ok) return []
+  const payload = await response.json()
+  const articles = Array.isArray(payload?.articles) ? payload.articles : []
+
+  return articles.map(articleRaw => {
+    const article =
+      typeof articleRaw === 'object' && articleRaw !== null ? (articleRaw as GdeltArticle) : {}
+
+    const title = typeof article.title === 'string' ? article.title : 'Civic action'
+    const direction: 1 | -1 = /press freedom|protect|support|rally|march|protest/i.test(
+      title.toLowerCase(),
+    )
+      ? 1
+      : -1
+
+    return {
+      id: `gd-${String(article.url ?? title)}`,
+      date: toISO(typeof article.seendate === 'string' ? article.seendate : undefined),
+      title,
+      url: typeof article.url === 'string' ? article.url : undefined,
+      category: 'Civil Society',
+      direction,
+      magnitude: 1.5,
+      confidence: 0.75,
+    }
+  })
+}
+
+export async function fetchLiveBlend(): Promise<EventItem[]> {
+  const [courtListener, gdelt] = await Promise.all([
+    fetchCourtListenerLive(),
+    fetchGdeltLive(),
+  ])
+
+  return [...courtListener, ...gdelt].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  )
+}


### PR DESCRIPTION
## Summary
- filter out future-dated items when building the index history and add an event merge helper
- wire the tracker page for background JSON refreshes, public live polling, and improved sparkline framing
- add live source fetchers and an hourly ingest/export GitHub Action for automated deployments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c1bd87a4833297ce97e64b769982