### PR TITLE
Add migration runner and ingest wiring

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
-import { migrate, pool, upsertEvents } from './db.js'
+import { pool, upsertEvents } from './db.js'
+import { migrate } from './migrate.js'
 import { fetchCourtListener } from './ingest-courtlistener.js'
 
 async function run(cmd?: string) {

--- a/backend/src/ingest-courtlistener.ts
+++ b/backend/src/ingest-courtlistener.ts
@@ -13,9 +13,9 @@ function toISO(d?: string) {
 
 /** Minimal heuristic mapping to EventItem */
 export async function fetchCourtListener(): Promise<EventItem[]> {
-  const r = await fetch(CL_URL, { cache: 'no-store' })
+  const r = await fetch(CL_URL)
   if (!r.ok) return []
-  const json = await r.json()
+  const json = (await r.json()) as { results?: any[] }
   const results: any[] = json?.results ?? []
 
   return results.map((o): EventItem => {

--- a/backend/src/migrate.ts
+++ b/backend/src/migrate.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { Pool } from 'pg'
+
+export async function migrate() {
+  const { DATABASE_URL } = process.env
+  if (!DATABASE_URL) throw new Error('DATABASE_URL is not set')
+
+  const pool = new Pool({ connectionString: DATABASE_URL })
+  const client = await pool.connect()
+  try {
+    const sqlPath = join(process.cwd(), 'backend', 'migrations', '001_init.sql')
+    const fallbackPath = join(process.cwd(), 'migrations', '001_init.sql')
+    let sql: string | undefined
+
+    try {
+      sql = await readFile(sqlPath, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+
+    if (!sql) {
+      sql = await readFile(fallbackPath, 'utf8')
+    }
+
+    await client.query('begin')
+    await client.query(sql)
+    await client.query('commit')
+    console.log('✅ Migration applied')
+  } catch (e) {
+    await client.query('rollback')
+    throw e
+  } finally {
+    client.release()
+    await pool.end()
+  }
+}

--- a/backend/src/pg.d.ts
+++ b/backend/src/pg.d.ts
@@ -1,0 +1,23 @@
+declare module 'pg' {
+  export interface PoolConfig {
+    connectionString?: string
+    max?: number
+  }
+
+  export interface QueryResult<T = any> {
+    rows: T[]
+    rowCount?: number
+  }
+
+  export interface PoolClient {
+    query<T = any>(text: string, params?: any[]): Promise<QueryResult<T>>
+    release(): void
+  }
+
+  export class Pool {
+    constructor(config?: PoolConfig)
+    connect(): Promise<PoolClient>
+    query<T = any>(text: string, params?: any[]): Promise<QueryResult<T>>
+    end(): Promise<void>
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated migration runner that loads the SQL file and applies it using pg
- update the CLI entrypoint to call the new migrate helper and keep ingest wiring intact
- add minimal pg type declarations and tweak the CourtListener fetcher for strict TypeScript

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d58f45a48332a75e0db24c2f5d33