### PR TITLE
Handle sslmode when building pool config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,7 @@
-# Supabase Postgres connection string (use pooler + sslmode=no-verify for local/CI)
+# Supabase Postgres connection string
 # URL-encode special password characters: # -> %23, @ -> %40, ? -> %3F, & -> %26
-# Example:
+# For local/CI (relaxed TLS validation):
 # DATABASE_URL=postgresql://postgres.<projectref>:YOUR_PASSWORD@aws-1-us-east-1.pooler.supabase.com:6543/postgres?sslmode=no-verify
+# For production (verify TLS certificates):
+# DATABASE_URL=postgresql://postgres.<projectref>:YOUR_PASSWORD@aws-1-us-east-1.pooler.supabase.com:6543/postgres?sslmode=require
 DATABASE_URL=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,5 @@
-# Supabase Postgres connection string
-# Format: postgres://USER:PASSWORD@HOST:PORT/DATABASE
+# Supabase Postgres connection string (use pooler + sslmode=no-verify for local/CI)
+# URL-encode special password characters: # -> %23, @ -> %40, ? -> %3F, & -> %26
+# Example:
+# DATABASE_URL=postgresql://postgres.<projectref>:YOUR_PASSWORD@aws-1-us-east-1.pooler.supabase.com:6543/postgres?sslmode=no-verify
 DATABASE_URL=

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,27 +1,14 @@
 // backend/src/db.ts
-import { Pool, type PoolConfig } from 'pg'
+import { Pool } from 'pg'
 
 const { DATABASE_URL } = process.env
 if (!DATABASE_URL) throw new Error('DATABASE_URL is not set')
 
-function createPoolConfig(databaseUrl: string): PoolConfig {
-  const url = new URL(databaseUrl)
-
-  const sslMode = url.searchParams.get('sslmode')?.toLowerCase()
-  if (sslMode) {
-    url.searchParams.delete('sslmode')
-  }
-
-  const sslDisabled = sslMode === 'disable'
-
-  return {
-    connectionString: url.toString(),
-    max: 5,
-    ssl: sslDisabled ? false : { rejectUnauthorized: false },
-  }
-}
-
-export const pool = new Pool(createPoolConfig(DATABASE_URL))
+// Rely on sslmode from the DATABASE_URL (e.g. ?sslmode=no-verify with Supabase pooler)
+export const pool = new Pool({
+  connectionString: DATABASE_URL,
+  max: 5,
+})
 
 type UpsertRow = {
   id: string

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,14 +1,27 @@
 // backend/src/db.ts
-import { Pool } from 'pg'
+import { Pool, type PoolConfig } from 'pg'
 
 const { DATABASE_URL } = process.env
 if (!DATABASE_URL) throw new Error('DATABASE_URL is not set')
 
-export const pool = new Pool({
-  connectionString: DATABASE_URL,
-  max: 5,
-  ssl: { rejectUnauthorized: false }, // REQUIRED for Supabase TLS
-})
+function createPoolConfig(databaseUrl: string): PoolConfig {
+  const url = new URL(databaseUrl)
+
+  const sslMode = url.searchParams.get('sslmode')?.toLowerCase()
+  if (sslMode) {
+    url.searchParams.delete('sslmode')
+  }
+
+  const sslDisabled = sslMode === 'disable'
+
+  return {
+    connectionString: url.toString(),
+    max: 5,
+    ssl: sslDisabled ? false : { rejectUnauthorized: false },
+  }
+}
+
+export const pool = new Pool(createPoolConfig(DATABASE_URL))
 
 type UpsertRow = {
   id: string

--- a/backend/src/migrate.ts
+++ b/backend/src/migrate.ts
@@ -1,12 +1,8 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { Pool } from 'pg'
+import { pool } from './db.js'
 
 export async function migrate() {
-  const { DATABASE_URL } = process.env
-  if (!DATABASE_URL) throw new Error('DATABASE_URL is not set')
-
-  const pool = new Pool({ connectionString: DATABASE_URL })
   const client = await pool.connect()
   try {
     const sqlPath = join(process.cwd(), 'backend', 'migrations', '001_init.sql')
@@ -32,6 +28,5 @@ export async function migrate() {
     throw e
   } finally {
     client.release()
-    await pool.end()
   }
 }

--- a/backend/src/pg.d.ts
+++ b/backend/src/pg.d.ts
@@ -2,7 +2,9 @@ declare module 'pg' {
   export interface PoolConfig {
     connectionString?: string
     max?: number
-    ssl?: false | { rejectUnauthorized?: boolean }
+    idleTimeoutMillis?: number
+    connectionTimeoutMillis?: number
+    ssl?: boolean | { rejectUnauthorized?: boolean }
   }
 
   export interface QueryResult<T = any> {

--- a/backend/src/pg.d.ts
+++ b/backend/src/pg.d.ts
@@ -2,7 +2,7 @@ declare module 'pg' {
   export interface PoolConfig {
     connectionString?: string
     max?: number
-    ssl?: { rejectUnauthorized?: boolean }
+    ssl?: false | { rejectUnauthorized?: boolean }
   }
 
   export interface QueryResult<T = any> {


### PR DESCRIPTION
## Summary
- ensure the pg pool strips the sslmode query parameter so the driver keeps our TLS options
- allow the PoolConfig type augmentation to accept disabling SSL explicitly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9ff4f24c083329ba10381e315eda8